### PR TITLE
feat: add kana tracing and SRS engine

### DIFF
--- a/JapaneseBuddy/App/JapaneseBuddyApp.swift
+++ b/JapaneseBuddy/App/JapaneseBuddyApp.swift
@@ -1,1 +1,15 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import SwiftUI
+
+/// Entry point wiring the shared `DeckStore` and initial navigation stack.
+@main
+struct JapaneseBuddyApp: App {
+    @StateObject private var store = DeckStore()
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack { HomeView() }
+                .environmentObject(store)
+        }
+    }
+}
+

--- a/JapaneseBuddy/Features/Home/HomeView.swift
+++ b/JapaneseBuddy/Features/Home/HomeView.swift
@@ -1,1 +1,52 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import SwiftUI
+
+/// Landing screen with deck toggles and navigation tiles.
+struct HomeView: View {
+    @EnvironmentObject var store: DeckStore
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Picker("Deck", selection: $store.currentType) {
+                Text("Hiragana").tag(CardType.hiragana)
+                Text("Katakana").tag(CardType.katakana)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+
+            Toggle("Pencil only", isOn: $store.pencilOnly)
+                .padding(.horizontal)
+
+            HStack(spacing: 20) {
+                NavigationLink {
+                    KanaTraceView()
+                } label: {
+                    tile(title: "Kana Trace", count: traceCount)
+                }
+
+                NavigationLink {
+                    SRSView()
+                } label: {
+                    tile(title: "SRS", count: srsCount)
+                }
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+        .navigationTitle("Home")
+    }
+
+    private var traceCount: Int { store.dueCards(type: store.currentType).count }
+    private var srsCount: Int { traceCount }
+
+    @ViewBuilder
+    private func tile(title: String, count: Int) -> some View {
+        VStack {
+            Text(title).font(.title2)
+            Text("\(count) due").font(.caption).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 120)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.blue.opacity(0.1)))
+    }
+}
+

--- a/JapaneseBuddy/Features/SRS/SRSView.swift
+++ b/JapaneseBuddy/Features/SRS/SRSView.swift
@@ -1,1 +1,48 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import SwiftUI
+
+/// Simple SRS review screen with grading buttons.
+struct SRSView: View {
+    @EnvironmentObject var store: DeckStore
+    @State private var current: Card?
+    @State private var showBack = false
+    private let speaker = Speaker()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            if let card = current {
+                Text(showBack ? card.back : card.front)
+                    .font(.system(size: 80))
+                    .padding()
+                    .onTapGesture { showBack.toggle() }
+
+                HStack(spacing: 20) {
+                    Button("Speak") { speaker.speak(card.front) }
+                    Button("Flip") { showBack.toggle() }
+                }
+
+                HStack(spacing: 20) {
+                    Button("Hard") { grade(.hard) }
+                    Button("Good") { grade(.good) }
+                    Button("Easy") { grade(.easy) }
+                }
+            } else {
+                Text("All caught up")
+            }
+        }
+        .onAppear(perform: next)
+        .navigationTitle("SRS")
+    }
+
+    private func next() {
+        current = store.dueCards(type: store.currentType).first
+        showBack = false
+    }
+
+    private func grade(_ rating: Rating) {
+        guard var card = current else { return }
+        SRS.apply(rating, to: &card)
+        store.update(card)
+        next()
+    }
+}
+

--- a/JapaneseBuddy/Models/Card.swift
+++ b/JapaneseBuddy/Models/Card.swift
@@ -1,1 +1,40 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import Foundation
+
+/// Type of study card. `kana` keeps the test targets compiling.
+enum CardType: String, Codable, CaseIterable, Identifiable {
+    case hiragana
+    case katakana
+
+    var id: String { rawValue }
+
+    /// Compatibility case for early tests; maps to hiragana.
+    static var kana: CardType { .hiragana }
+}
+
+/// User rating for a review step.
+enum Rating: String, Codable { case hard, good, easy }
+
+/// Simple review stats.
+struct CardStats: Codable { var reviews = 0 }
+
+/// Flash card model backing SRS and tracing screens.
+struct Card: Identifiable, Codable {
+    var id = UUID()
+    var type: CardType
+    var front: String
+    var back: String
+    var reading: String = ""
+    var ease: Double = 2.5
+    var interval: Int = 0
+    var nextDue: Date = .distantPast
+    var stats = CardStats()
+
+    init(id: UUID = UUID(), type: CardType, front: String, back: String, reading: String = "") {
+        self.id = id
+        self.type = type
+        self.front = front
+        self.back = back
+        self.reading = reading.isEmpty ? back : reading
+    }
+}
+

--- a/JapaneseBuddy/Models/SRS.swift
+++ b/JapaneseBuddy/Models/SRS.swift
@@ -1,1 +1,28 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import Foundation
+
+/// Simplified SM‑2 spaced repetition algorithm.
+enum SRS {
+    /// Applies a rating to mutate card scheduling values.
+    static func apply(_ rating: Rating, to card: inout Card, today: Date = Date()) {
+        // ease adjustments
+        switch rating {
+        case .hard: card.ease = max(1.3, card.ease - 0.2)
+        case .good: break
+        case .easy: card.ease += 0.15
+        }
+
+        // interval progression: 0→1→3→round(prev*ease)
+        if card.interval == 0 {
+            card.interval = 1
+        } else if card.interval == 1 {
+            card.interval = 3
+        } else {
+            card.interval = max(1, Int((Double(card.interval) * card.ease).rounded()))
+        }
+
+        let next = Calendar.current.date(byAdding: .day, value: card.interval, to: today) ?? today
+        card.nextDue = next
+        card.stats.reviews += 1
+    }
+}
+

--- a/JapaneseBuddy/Resources/SeedData.swift
+++ b/JapaneseBuddy/Resources/SeedData.swift
@@ -1,1 +1,20 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import Foundation
+
+/// Static seed data for initial decks.
+enum SeedData {
+    private static let hira = "あ い う え お か き く け こ さ し す せ そ た ち つ て と な に ぬ ね の は ひ ふ へ ほ ま み む め も や ゆ よ ら り る れ ろ わ を ん".split(separator: " ").map(String.init)
+    private static let kata = "ア イ ウ エ オ カ キ ク ケ コ サ シ ス セ ソ タ チ ツ テ ト ナ ニ ヌ ネ ノ ハ ヒ フ ヘ ホ マ ミ ム メ モ ヤ ユ ヨ ラ リ ル レ ロ ワ ヲ ン".split(separator: " ").map(String.init)
+    private static let romaji = "a i u e o ka ki ku ke ko sa shi su se so ta chi tsu te to na ni nu ne no ha hi fu he ho ma mi mu me mo ya yu yo ra ri ru re ro wa wo n".split(separator: " ").map(String.init)
+
+    static func makeCards() -> [Card] {
+        var cards: [Card] = []
+        for (s, r) in zip(hira, romaji) {
+            cards.append(Card(type: .hiragana, front: s, back: r, reading: r))
+        }
+        for (s, r) in zip(kata, romaji) {
+            cards.append(Card(type: .katakana, front: s, back: r, reading: r))
+        }
+        return cards
+    }
+}
+

--- a/JapaneseBuddy/Services/DeckStore.swift
+++ b/JapaneseBuddy/Services/DeckStore.swift
@@ -1,1 +1,56 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import Foundation
+import Combine
+
+/// Manages persistence and due card queries.
+final class DeckStore: ObservableObject {
+    @Published var cards: [Card] = []
+    @Published var pencilOnly = true
+    @Published var currentType: CardType = .hiragana
+
+    private let url: URL
+    private var saveTask: AnyCancellable?
+
+    init() {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        url = docs.appendingPathComponent("deck.json")
+        load()
+        // save on changes with debounce
+        saveTask = $cards
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.global())
+            .sink { [weak self] _ in self?.save() }
+    }
+
+    /// Loads cards from disk or seed data on first launch.
+    private func load() {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([Card].self, from: data) else {
+            cards = SeedData.makeCards()
+            save()
+            return
+        }
+        cards = decoded
+    }
+
+    /// Persists cards atomically.
+    private func save() {
+        guard let data = try? JSONEncoder().encode(cards) else { return }
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch { print("Deck save error: \(error)") }
+    }
+
+    /// Updates an existing card in memory and schedules persistence.
+    func update(_ card: Card) {
+        if let idx = cards.firstIndex(where: { $0.id == card.id }) {
+            cards[idx] = card
+        }
+    }
+
+    /// Returns cards due on or before the given date filtered by type.
+    func dueCards(type: CardType?, on date: Date = Date()) -> [Card] {
+        cards.filter { card in
+            card.nextDue <= date && (type == nil || card.type == type!)
+        }
+    }
+}
+

--- a/JapaneseBuddy/Services/Speaker.swift
+++ b/JapaneseBuddy/Services/Speaker.swift
@@ -1,1 +1,13 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import AVFoundation
+
+/// Lightweight wrapper around `AVSpeechSynthesizer` for Japanese output.
+final class Speaker {
+    private let synth = AVSpeechSynthesizer()
+
+    func speak(_ text: String) {
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "ja-JP")
+        synth.speak(utterance)
+    }
+}
+

--- a/JapaneseBuddy/Services/TemplateRenderer.swift
+++ b/JapaneseBuddy/Services/TemplateRenderer.swift
@@ -1,1 +1,24 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import UIKit
+
+/// Renders kana glyphs into mask images for tracing.
+enum TemplateRenderer {
+    static func image(for glyph: String, size: CGSize) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+
+            let font = UIFont.systemFont(ofSize: size.width * 0.8)
+            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: UIColor.black]
+            let textSize = glyph.size(withAttributes: attrs)
+            let rect = CGRect(
+                x: (size.width - textSize.width) / 2,
+                y: (size.height - textSize.height) / 2,
+                width: textSize.width,
+                height: textSize.height
+            )
+            glyph.draw(in: rect, withAttributes: attrs)
+        }
+    }
+}
+

--- a/JapaneseBuddy/Services/TraceCanvas.swift
+++ b/JapaneseBuddy/Services/TraceCanvas.swift
@@ -1,1 +1,55 @@
-// TODO: Will be filled in JP-APP-001 sprint. Keep files ≤150 LOC when implemented.
+import SwiftUI
+import PencilKit
+import UIKit
+
+/// SwiftUI wrapper for `PKCanvasView` used for tracing practice.
+struct TraceCanvas: UIViewRepresentable {
+    @Binding var canvasView: PKCanvasView?
+    var pencilOnly: Bool
+
+    func makeUIView(context: Context) -> PKCanvasView {
+        let view = PKCanvasView()
+        view.drawingPolicy = pencilOnly ? .pencilOnly : .anyInput
+        canvasView = view
+        return view
+    }
+
+    func updateUIView(_ uiView: PKCanvasView, context: Context) {
+        uiView.drawingPolicy = pencilOnly ? .pencilOnly : .anyInput
+    }
+}
+
+/// Utilities for evaluating traced drawings.
+enum TraceEvaluator {
+    /// Renders the drawing into an image of given size.
+    static func snapshot(_ view: PKCanvasView, size: CGSize) -> UIImage {
+        view.drawing.image(from: CGRect(origin: .zero, size: size), scale: 1)
+    }
+
+    /// Rough overlap score between user drawing and template mask.
+    static func overlapScore(drawing: UIImage, template: UIImage) -> Double {
+        guard let d = drawing.cgImage, let t = template.cgImage,
+              d.width == t.width, d.height == t.height else { return 0 }
+        let width = d.width, height = d.height
+        let pixels = width * height
+        let space = CGColorSpaceCreateDeviceGray()
+        var dBuf = [UInt8](repeating: 255, count: pixels)
+        var tBuf = [UInt8](repeating: 255, count: pixels)
+        let dCtx = CGContext(data: &dBuf, width: width, height: height, bitsPerComponent: 8,
+                             bytesPerRow: width, space: space, bitmapInfo: 0)!
+        dCtx.draw(d, in: CGRect(x: 0, y: 0, width: width, height: height))
+        let tCtx = CGContext(data: &tBuf, width: width, height: height, bitsPerComponent: 8,
+                             bytesPerRow: width, space: space, bitmapInfo: 0)!
+        tCtx.draw(t, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        var match = 0, total = 0
+        for i in 0..<pixels {
+            if tBuf[i] < 200 { // template stroke
+                total += 1
+                if dBuf[i] < 200 { match += 1 }
+            }
+        }
+        return total == 0 ? 0 : Double(match) / Double(total)
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Private iPad app for kana and kanji practice with Apple Pencil and a spaced repe
 ## Run
 Open in Xcode, select an iPad simulator or device, and press **Run**.
 
+### Run & Test
+- Build: `make build` (uses `xcodebuild -scheme JapaneseBuddy`)
+- Tests: `make test`
+
 ## Privacy
 All data stays on the device. No analytics or third-party SDKs.
 


### PR DESCRIPTION
## Summary
- implement Card model, SRS algorithm and deck persistence
- add kana tracing canvas, SRS review view and home dashboard
- provide seed data and Japanese speech synthesis

## Testing
- `make format` *(fails: swiftformat: No such file or directory)*
- `make lint` *(swiftlint: not found)*
- `make build` *(xcodebuild: No such file or directory)*
- `make test` *(xcodebuild: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a40b357040832e8a156b762fc5e94b