### PR TITLE
feat: add daily goals and reminders

### DIFF
--- a/JapaneseBuddy/Features/Home/DailyGoalCard.swift
+++ b/JapaneseBuddy/Features/Home/DailyGoalCard.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct DailyGoalCard: View {
+    let progress: GoalProgress
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Daily Goal").font(.headline)
+            HStack {
+                Label("New \(progress.newDone)/\(progress.target.newTarget)", systemImage: "sparkles")
+                Spacer()
+                Label("Review \(progress.reviewDone)/\(progress.target.reviewTarget)", systemImage: "arrow.triangle.2.circlepath")
+            }.font(.subheadline)
+            ProgressView(value: ratio(progress)).tint(.primary)
+        }
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(.quaternary))
+    }
+    private func ratio(_ p: GoalProgress) -> Double {
+        let done = p.newDone + p.reviewDone
+        let total = max(1, p.target.newTarget + p.target.reviewTarget)
+        return Double(done) / Double(total)
+    }
+}

--- a/JapaneseBuddy/Features/Home/HomeView.swift
+++ b/JapaneseBuddy/Features/Home/HomeView.swift
@@ -16,6 +16,9 @@ struct HomeView: View {
             Toggle("Pencil only", isOn: $store.pencilOnly)
                 .padding(.horizontal)
 
+            DailyGoalCard(progress: store.progressToday())
+                .padding(.horizontal)
+
             HStack(spacing: 20) {
                 NavigationLink {
                     KanaTraceView()
@@ -34,6 +37,13 @@ struct HomeView: View {
             Spacer()
         }
         .navigationTitle("Home")
+        .toolbar {
+            NavigationLink {
+                SettingsView()
+            } label: {
+                Image(systemName: "gear")
+            }
+        }
     }
 
     private var traceCount: Int { store.dueCards(type: store.currentType).count }

--- a/JapaneseBuddy/Features/KanaTraceView.swift
+++ b/JapaneseBuddy/Features/KanaTraceView.swift
@@ -56,8 +56,10 @@ struct KanaTraceView: View {
         let score = TraceEvaluator.overlapScore(drawing: drawn, template: template)
         if score > 0.6 {
             var updated = card
+            let wasNew = updated.interval == 0
             SRS.apply(.good, to: &updated)
             store.update(updated)
+            if wasNew { store.logNew(for: updated) }
             next()
         }
     }

--- a/JapaneseBuddy/Features/SRS/SRSView.swift
+++ b/JapaneseBuddy/Features/SRS/SRSView.swift
@@ -42,6 +42,7 @@ struct SRSView: View {
         guard var card = current else { return }
         SRS.apply(rating, to: &card)
         store.update(card)
+        store.logReview(for: card)
         next()
     }
 }

--- a/JapaneseBuddy/Features/Settings/SettingsView.swift
+++ b/JapaneseBuddy/Features/Settings/SettingsView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var store: DeckStore
+
+    var body: some View {
+        Form {
+            Section("Daily Goal") {
+                Stepper("New \(store.dailyGoal.newTarget)", value: $store.dailyGoal.newTarget, in: 0...100)
+                Stepper("Review \(store.dailyGoal.reviewTarget)", value: $store.dailyGoal.reviewTarget, in: 0...500)
+            }
+            Section("Reminders") {
+                Toggle("Enable", isOn: $store.notificationsEnabled)
+                DatePicker("Time", selection: timeBinding, displayedComponents: .hourAndMinute)
+                    .disabled(!store.notificationsEnabled)
+            }
+        }
+        .navigationTitle("Settings")
+        .onChange(of: store.notificationsEnabled) { _ in updateNotifications() }
+        .onChange(of: store.reminderTime) { _ in updateNotifications() }
+    }
+
+    private var timeBinding: Binding<Date> {
+        Binding<Date>(
+            get: {
+                if let comps = store.reminderTime, let d = Calendar.current.date(from: comps) { return d }
+                return Calendar.current.date(from: DateComponents(hour: 20)) ?? Date()
+            },
+            set: { store.reminderTime = Calendar.current.dateComponents([.hour, .minute], from: $0) }
+        )
+    }
+
+    private func updateNotifications() {
+        Task {
+            if store.notificationsEnabled, let comps = store.reminderTime {
+                await LocalNotifications.requestPermission()
+                try? await LocalNotifications.scheduleDaily(at: comps)
+            } else {
+                await LocalNotifications.cancel(id: "daily-goal")
+            }
+        }
+    }
+}

--- a/JapaneseBuddy/Models/Goal.swift
+++ b/JapaneseBuddy/Models/Goal.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct DailyGoal: Codable {
+    var newTarget: Int = 10
+    var reviewTarget: Int = 10
+}
+
+enum SessionKind: String, Codable { case new, review }
+
+struct SessionLogEntry: Codable {
+    let date: Date
+    let kind: SessionKind
+    let cardID: UUID
+}
+
+struct GoalProgress {
+    let newDone: Int
+    let reviewDone: Int
+    let target: DailyGoal
+}
+
+extension GoalProgress {
+    static func compute(entries: [SessionLogEntry], on day: Date, goal: DailyGoal, cal: Calendar = .current) -> GoalProgress {
+        let today = entries.filter { cal.isDate($0.date, inSameDayAs: day) }
+        let newDone = today.filter { $0.kind == .new }.count
+        let reviewDone = today.filter { $0.kind == .review }.count
+        return GoalProgress(newDone: newDone, reviewDone: reviewDone, target: goal)
+    }
+}

--- a/JapaneseBuddy/Services/LocalNotifications.swift
+++ b/JapaneseBuddy/Services/LocalNotifications.swift
@@ -1,0 +1,25 @@
+import UserNotifications
+
+enum LocalNotifications {
+    static func requestPermission() async {
+        _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+    }
+
+    static func scheduleDaily(at components: DateComponents, id: String = "daily-goal") async throws {
+        let center = UNUserNotificationCenter.current()
+        await cancel(id: id)
+        let content = UNMutableNotificationContent()
+        content.title = "JapaneseBuddy"
+        content.body = "Time for today’s practice!"
+        var comps = DateComponents()
+        comps.hour = components.hour
+        comps.minute = components.minute
+        let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: true)
+        let req = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+        try await center.add(req)
+    }
+
+    static func cancel(id: String) async {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
+    }
+}

--- a/JapaneseBuddyTests/GoalProgressTests.swift
+++ b/JapaneseBuddyTests/GoalProgressTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import JapaneseBuddyProj
+
+final class GoalProgressTests: XCTestCase {
+    func testCompute() {
+        let cal = Calendar.current
+        let today = Date()
+        let yesterday = cal.date(byAdding: .day, value: -1, to: today)!
+        let goal = DailyGoal(newTarget: 5, reviewTarget: 5)
+        let entries: [SessionLogEntry] = [
+            SessionLogEntry(date: today, kind: .new, cardID: UUID()),
+            SessionLogEntry(date: today, kind: .new, cardID: UUID()),
+            SessionLogEntry(date: today, kind: .review, cardID: UUID()),
+            SessionLogEntry(date: today, kind: .review, cardID: UUID()),
+            SessionLogEntry(date: today, kind: .review, cardID: UUID()),
+            SessionLogEntry(date: yesterday, kind: .new, cardID: UUID()),
+            SessionLogEntry(date: yesterday, kind: .review, cardID: UUID())
+        ]
+        let prog = GoalProgress.compute(entries: entries, on: today, goal: goal, cal: cal)
+        XCTAssertEqual(prog.newDone, 2)
+        XCTAssertEqual(prog.reviewDone, 3)
+        XCTAssertEqual(prog.target.newTarget, goal.newTarget)
+        XCTAssertEqual(prog.target.reviewTarget, goal.reviewTarget)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ All data stays on the device. No analytics or third-party SDKs.
 
 ## License
 MIT — see [LICENSE](LICENSE).
+
+## Goals & Reminders
+Set daily targets for new and review cards and track progress on the Home screen. Configure goals and optional local reminders in Settings; notifications stay on-device and are fully optional.


### PR DESCRIPTION
## Summary
- track daily goal progress and session logging
- add settings with notification scheduling
- show daily goal card on home screen

## Testing
- `make format` *(fails: swiftformat: No such file or directory)*
- `make lint`
- `make test` *(fails: xcodebuild: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a40fe751a0832e8178ff02e6d57f60