### PR TITLE
feat: add can-do lessons with runner and progress

### DIFF
--- a/JapaneseBuddy/Features/Home/HomeView.swift
+++ b/JapaneseBuddy/Features/Home/HomeView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Landing screen with deck toggles and navigation tiles.
 struct HomeView: View {
     @EnvironmentObject var store: DeckStore
+    @EnvironmentObject var lessonStore: LessonStore
 
     var body: some View {
         VStack(spacing: 24) {
@@ -31,6 +32,12 @@ struct HomeView: View {
                 } label: {
                     tile(title: "SRS", count: srsCount)
                 }
+
+                NavigationLink {
+                    LessonListView()
+                } label: {
+                    tile(title: "Lessons", count: lessonCount)
+                }
             }
             .padding(.horizontal)
 
@@ -48,6 +55,7 @@ struct HomeView: View {
 
     private var traceCount: Int { store.dueCards(type: store.currentType).count }
     private var srsCount: Int { traceCount }
+    private var lessonCount: Int { lessonStore.lessons().count }
 
     @ViewBuilder
     private func tile(title: String, count: Int) -> some View {

--- a/JapaneseBuddy/Features/Lessons/CheckView.swift
+++ b/JapaneseBuddy/Features/Lessons/CheckView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Final self assessment with star rating.
+struct CheckView: View {
+    struct Star: Identifiable { let id: Int }
+    let current: Int
+    var onFinish: (Int) -> Void
+    @State private var rating = 0
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Can-do Check").font(.title2)
+            HStack {
+                let stars = [Star(id: 1), Star(id: 2), Star(id: 3)]
+                ForEach(stars) { star in
+                    Image(systemName: star.id <= rating ? "star.fill" : "star")
+                        .foregroundStyle(.yellow)
+                        .font(.largeTitle)
+                        .onTapGesture { rating = star.id }
+                }
+            }
+            Button("Done") { onFinish(rating) }
+                .disabled(rating == 0)
+            Spacer()
+        }
+        .padding()
+        .onAppear { rating = current }
+    }
+}
+

--- a/JapaneseBuddy/Features/Lessons/LessonListView.swift
+++ b/JapaneseBuddy/Features/Lessons/LessonListView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Displays available lessons with star progress.
+struct LessonListView: View {
+    @EnvironmentObject var lessons: LessonStore
+
+    var body: some View {
+        List {
+            ForEach(lessons.lessons()) { lesson in
+                let progress = lessons.progress(for: lesson.id)
+                NavigationLink {
+                    LessonRunnerView(lesson: lesson)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(lesson.title).font(.headline)
+                            Text(lesson.canDo).font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(String(repeating: "★", count: progress.stars))
+                            .foregroundStyle(.yellow)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Lessons")
+    }
+}
+

--- a/JapaneseBuddy/Features/Lessons/ListeningView.swift
+++ b/JapaneseBuddy/Features/Lessons/ListeningView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Multiple choice listening activity.
+struct ListeningView: View {
+    struct Item: Identifiable { let id: Int; let text: String }
+    let prompt: String
+    let choices: [String]
+    let answer: Int
+    @Binding var selection: Int?
+
+    var body: some View {
+        let items = choices.enumerated().map { Item(id: $0.offset, text: $0.element) }
+        return VStack(alignment: .leading, spacing: 20) {
+            Text(prompt).font(.title3)
+            ForEach(items) { item in
+                Button(item.text) { selection = item.id }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .background(background(item.id))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            Spacer()
+        }
+        .padding()
+    }
+
+    private func background(_ idx: Int) -> Color {
+        guard let sel = selection else { return Color.blue.opacity(0.1) }
+        if idx == sel {
+            return sel == answer ? .green.opacity(0.3) : .red.opacity(0.3)
+        } else if idx == answer {
+            return .green.opacity(0.3)
+        } else {
+            return Color.blue.opacity(0.1)
+        }
+    }
+}
+

--- a/JapaneseBuddy/Features/Lessons/ObjectiveView.swift
+++ b/JapaneseBuddy/Features/Lessons/ObjectiveView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// Displays the lesson objective text.
+struct ObjectiveView: View {
+    let text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text(text).font(.title2)
+            Spacer()
+        }
+        .padding()
+    }
+}
+

--- a/JapaneseBuddy/Features/Lessons/ReadingView.swift
+++ b/JapaneseBuddy/Features/Lessons/ReadingView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Reading comprehension via multiple choice.
+struct ReadingView: View {
+    struct Item: Identifiable { let id: Int; let text: String }
+    let prompt: String
+    let items: [String]
+    let answer: Int
+    @Binding var selection: Int?
+
+    var body: some View {
+        let choices = items.enumerated().map { Item(id: $0.offset, text: $0.element) }
+        return VStack(alignment: .leading, spacing: 20) {
+            Text(prompt).font(.title3)
+            ForEach(choices) { item in
+                Button(item.text) { selection = item.id }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .background(background(item.id))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            Spacer()
+        }
+        .padding()
+    }
+
+    private func background(_ idx: Int) -> Color {
+        guard let sel = selection else { return Color.blue.opacity(0.1) }
+        if idx == sel {
+            return sel == answer ? .green.opacity(0.3) : .red.opacity(0.3)
+        } else if idx == answer {
+            return .green.opacity(0.3)
+        } else {
+            return Color.blue.opacity(0.1)
+        }
+    }
+}
+

--- a/JapaneseBuddy/Features/Lessons/ShadowingView.swift
+++ b/JapaneseBuddy/Features/Lessons/ShadowingView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Plays each segment with Japanese TTS for shadowing practice.
+struct ShadowingView: View {
+    struct Segment: Identifiable { let id = UUID(); let text: String }
+    let segments: [String]
+    private let speaker = Speaker()
+
+    var body: some View {
+        let items = segments.map { Segment(text: $0) }
+        return VStack(alignment: .leading, spacing: 16) {
+            ForEach(items) { seg in
+                HStack {
+                    Text(seg.text)
+                    Spacer()
+                    Button {
+                        speaker.speak(seg.text)
+                    } label: {
+                        Image(systemName: "play.circle").font(.title2)
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}
+

--- a/JapaneseBuddy/Models/Lesson.swift
+++ b/JapaneseBuddy/Models/Lesson.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Learning unit backed by a series of activities.
+struct Lesson: Codable, Identifiable {
+    var id: String
+    var title: String
+    var canDo: String
+    var activities: [Activity]
+    var tips: [String]
+    var kanjiWords: [String]
+
+    enum Activity: Codable {
+        case objective(text: String)
+        case shadow(segments: [String])
+        case listening(prompt: String, choices: [String], answer: Int)
+        case reading(prompt: String, items: [String], answer: Int)
+        case check
+
+        private enum CodingKeys: String, CodingKey {
+            case objective, shadow, listening, reading, check
+        }
+
+        private struct Objective: Codable { var text: String }
+        private struct Shadow: Codable { var segments: [String] }
+        private struct MCQ: Codable {
+            var prompt: String
+            var choices: [String]
+            var answer: Int
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let obj = try container.decodeIfPresent(Objective.self, forKey: .objective) {
+                self = .objective(text: obj.text)
+            } else if let sh = try container.decodeIfPresent(Shadow.self, forKey: .shadow) {
+                self = .shadow(segments: sh.segments)
+            } else if let mcq = try container.decodeIfPresent(MCQ.self, forKey: .listening) {
+                self = .listening(prompt: mcq.prompt, choices: mcq.choices, answer: mcq.answer)
+            } else if let mcq = try container.decodeIfPresent(MCQ.self, forKey: .reading) {
+                self = .reading(prompt: mcq.prompt, items: mcq.choices, answer: mcq.answer)
+            } else if container.contains(.check) {
+                self = .check
+            } else {
+                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Unknown activity"))
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case let .objective(text):
+                try container.encode(Objective(text: text), forKey: .objective)
+            case let .shadow(segments):
+                try container.encode(Shadow(segments: segments), forKey: .shadow)
+            case let .listening(prompt, choices, answer):
+                try container.encode(MCQ(prompt: prompt, choices: choices, answer: answer), forKey: .listening)
+            case let .reading(prompt, items, answer):
+                try container.encode(MCQ(prompt: prompt, choices: items, answer: answer), forKey: .reading)
+            case .check:
+                try container.encode([String: String](), forKey: .check)
+            }
+        }
+    }
+}
+

--- a/JapaneseBuddy/Models/LessonProgress.swift
+++ b/JapaneseBuddy/Models/LessonProgress.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Stored state for a lesson run.
+struct LessonProgress: Codable {
+    var lastStep: Int = 0
+    var stars: Int = 0
+    var completedAt: Date?
+}
+

--- a/JapaneseBuddy/Resources/lessons/A1-01-Greetings.json
+++ b/JapaneseBuddy/Resources/lessons/A1-01-Greetings.json
@@ -1,0 +1,13 @@
+{
+  "id":"A1-01",
+  "title":"Greetings",
+  "canDo":"Greet and say your name briefly",
+  "activities":[
+    {"objective":{"text":"Introduce yourself in a short sentence."}},
+    {"shadow":{"segments":["はじめまして。","わたしは アヤ です。"]}},
+    {"listening":{"prompt":"What does Aya say?","choices":["Nice to meet you","Good night","Thank you"],"answer":0}},
+    {"check":{}}
+  ],
+  "tips":["Use はじめまして at first meetings."],
+  "kanjiWords":["名","人","私"]
+}

--- a/JapaneseBuddy/Resources/lessons/A1-04-WhereYouLive.json
+++ b/JapaneseBuddy/Resources/lessons/A1-04-WhereYouLive.json
@@ -1,0 +1,14 @@
+{
+  "id":"A1-04",
+  "title":"Where you live",
+  "canDo":"Ask and answer where you live",
+  "activities":[
+    {"objective":{"text":"Say where you live with です."}},
+    {"shadow":{"segments":["わたしは イスタンブール に すんで います。"]}},
+    {"listening":{"prompt":"Where does the speaker live?","choices":["Ankara","Istanbul","Tokyo"],"answer":1}},
+    {"reading":{"prompt":"Find the address on the card.","items":["東京都 新宿区","イスタンブール ベシクタシュ","大阪市 西区"],"answer":1}},
+    {"check":{}}
+  ],
+  "tips":["に 住んでいます ‘live in’. Keep it simple at A1."],
+  "kanjiWords":["住","東","京"]
+}

--- a/JapaneseBuddy/Services/LessonStore.swift
+++ b/JapaneseBuddy/Services/LessonStore.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Manages lesson packs and per-lesson progress.
+final class LessonStore: ObservableObject {
+    private let deckStore: DeckStore
+    private var cached: [Lesson] = []
+
+    init(deckStore: DeckStore) {
+        self.deckStore = deckStore
+        loadLessons()
+    }
+
+    private func loadLessons() {
+        guard let urls = Bundle.main.urls(forResourcesWithExtension: "json", subdirectory: "lessons") else { return }
+        let decoder = JSONDecoder()
+        cached = urls.compactMap { url in
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return try? decoder.decode(Lesson.self, from: data)
+        }.sorted { $0.id < $1.id }
+    }
+
+    func lessons() -> [Lesson] { cached }
+
+    func progress(for id: String) -> LessonProgress {
+        deckStore.progress(for: id)
+    }
+
+    func updateProgress(_ p: LessonProgress, for id: String) {
+        deckStore.updateProgress(p, for: id)
+    }
+}
+

--- a/JapaneseBuddyProj/JapaneseBuddyProj/JapaneseBuddyProjApp.swift
+++ b/JapaneseBuddyProj/JapaneseBuddyProj/JapaneseBuddyProjApp.swift
@@ -9,7 +9,14 @@ import SwiftUI
 
 @main
 struct JapaneseBuddyProjApp: App {
-    @StateObject private var store = DeckStore()
+    @StateObject private var store: DeckStore
+    @StateObject private var lessonStore: LessonStore
+
+    init() {
+        let deck = DeckStore()
+        _store = StateObject(wrappedValue: deck)
+        _lessonStore = StateObject(wrappedValue: LessonStore(deckStore: deck))
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -17,6 +24,7 @@ struct JapaneseBuddyProjApp: App {
                 HomeView()
             }
             .environmentObject(store)
+            .environmentObject(lessonStore)
         }
     }
 }

--- a/JapaneseBuddyTests/LessonDecodeTests.swift
+++ b/JapaneseBuddyTests/LessonDecodeTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import JapaneseBuddy
+
+final class LessonDecodeTests: XCTestCase {
+    func testLessonsDecode() {
+        let store = LessonStore(deckStore: DeckStore())
+        let lessons = store.lessons()
+        XCTAssertEqual(lessons.count, 2)
+        XCTAssertEqual(lessons.first?.id, "A1-01")
+    }
+
+    func testProgressUpdatePersists() {
+        let deck = DeckStore()
+        let store = LessonStore(deckStore: deck)
+        var progress = store.progress(for: "A1-01")
+        progress.lastStep = 2
+        progress.stars = 3
+        store.updateProgress(progress, for: "A1-01")
+        let loaded = store.progress(for: "A1-01")
+        XCTAssertEqual(loaded.lastStep, 2)
+        XCTAssertEqual(loaded.stars, 3)
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ Set daily targets for new and review cards and track progress on the Home screen
 
 ## Stroke Order
 Trace practice shows optional stroke hints with numbered overlays and an animated preview. Use the Play/Pause button before tracing; disable hints in Settings if preferred.
+
+## Lessons
+Learn with short can-do based lessons. Each lesson starts with an objective, runs through activities like shadowing with Japanese TTS, listening or reading checks, then ends with a self-rated star review. Progress and stars save offline per lesson.

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,24 @@
+# Lessons Feature Design Notes
+
+## Overview
+Adds a minimal lesson system driven by JSON packs. Lessons follow a can-do flow: objective, activities, and a self-rated check.
+
+## Data
+- `Lesson` model with nested `Activity` enum for objective, shadowing, listening, reading and check steps.
+- `LessonProgress` stores `lastStep`, `stars`, `completedAt`.
+- Progress persists in `DeckStore.State` under `lessonProgress`.
+
+## Services
+- `LessonStore` loads `Resources/lessons/*.json` at startup and bridges progress calls to `DeckStore`.
+
+## UI
+- `HomeView` shows a new *Lessons* tile.
+- `LessonListView` lists lessons with star counts.
+- `LessonRunnerView` advances through activities:
+  - `ObjectiveView` shows the goal.
+  - `ShadowingView` speaks segments with `AVSpeechSynthesizer`.
+  - `ListeningView` and `ReadingView` provide simple MCQs.
+  - `CheckView` lets learners record 1–3 stars.
+
+## Tests
+`LessonDecodeTests` validates JSON decoding and progress persistence.


### PR DESCRIPTION
## Summary
- add Lesson and LessonProgress models with activity enum and persistence
- integrate LessonStore with DeckStore and expose progress API
- implement lesson list and runner with shadowing, MCQs and self-rating stars
- seed two A1 lessons and surface Lessons tile on Home
- document lessons feature and add basic decoding tests

## Testing
- `make format` *(fails: swiftformat: No such file or directory)*
- `make lint` *(fails: swiftlint: not found)*
- `make test` *(fails: xcodebuild: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a58518ca10832e8fb336b62951fd01