### PR TITLE
feat(settings): add deck backup and restore

### DIFF
--- a/JapaneseBuddy/Features/Settings/BackupSection.swift
+++ b/JapaneseBuddy/Features/Settings/BackupSection.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+
+struct BackupSection: View {
+    @EnvironmentObject var store: DeckStore
+    @State private var showExport = false
+    @State private var showImport = false
+    @State private var alert: AlertItem?
+    private let service = BackupService()
+
+    var body: some View {
+        Section("Backup & Restore") {
+            Button("Export deck.json") { showExport = true }
+            Button("Import deck.json") { showImport = true }
+        }
+        .sheet(isPresented: $showExport) {
+            ActivityView(items: [service.exportURL()])
+        }
+        .sheet(isPresented: $showImport) {
+            DocumentPicker { urls in handleImport(urls.first) }
+        }
+        .alert(item: $alert) { a in
+            Alert(title: Text(a.title), message: Text(a.message))
+        }
+    }
+
+    private func handleImport(_ url: URL?) {
+        guard let url else { return }
+        do {
+            try service.importDeck(from: url, into: store)
+            alert = AlertItem(title: "Import Complete", message: "Deck restored.")
+        } catch {
+            alert = AlertItem(title: "Import Failed", message: error.localizedDescription)
+        }
+    }
+
+    private struct AlertItem: Identifiable {
+        let title: String
+        let message: String
+        var id: String { title }
+    }
+}
+
+struct ActivityView: UIViewControllerRepresentable {
+    let items: [Any]
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+    func updateUIViewController(_ vc: UIActivityViewController, context: Context) {}
+}
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    var onPick: ([URL]) -> Void
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.json], asCopy: true)
+        picker.delegate = context.coordinator
+        return picker
+    }
+    func updateUIViewController(_ controller: UIDocumentPickerViewController, context: Context) {}
+    func makeCoordinator() -> Coordinator { Coordinator(onPick: onPick) }
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onPick: ([URL]) -> Void
+        init(onPick: @escaping ([URL]) -> Void) { self.onPick = onPick }
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            onPick(urls)
+        }
+    }
+}

--- a/JapaneseBuddy/Features/Settings/SettingsView.swift
+++ b/JapaneseBuddy/Features/Settings/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
             Section("Tracing") {
                 Toggle("Show Stroke Hints", isOn: $store.showStrokeHints)
             }
+            BackupSection()
             Section("Developer") {
                 Button("Reset Onboarding") { store.hasOnboarded = false }
                 .accessibilityLabel("Reset onboarding")

--- a/JapaneseBuddy/Services/BackupService.swift
+++ b/JapaneseBuddy/Services/BackupService.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct BackupService {
+    private var deckURL: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("deck.json")
+    }
+
+    func exportURL() -> URL { deckURL }
+
+    func importDeck(from url: URL, into store: DeckStore) throws {
+        let data = try Data(contentsOf: url)
+        let state: DeckStore.State
+        if let s = try? JSONDecoder().decode(DeckStore.State.self, from: data) {
+            state = s
+        } else if let cards = try? JSONDecoder().decode([Card].self, from: data) {
+            state = DeckStore.State(cards: cards)
+        } else {
+            throw BackupError.invalidSchema
+        }
+        try data.write(to: deckURL, options: [.atomic])
+        DispatchQueue.main.async { store.replace(with: state) }
+    }
+
+    enum BackupError: LocalizedError {
+        case invalidSchema
+        var errorDescription: String? { "Invalid deck.json format." }
+    }
+}

--- a/JapaneseBuddy/Services/DeckStore.swift
+++ b/JapaneseBuddy/Services/DeckStore.swift
@@ -136,4 +136,13 @@ final class DeckStore: ObservableObject {
         p.correct += 1
         kanjiProgress[lessonID] = p
     }
+
+    func replace(with s: State) {
+        cards = s.cards
+        dailyGoal = s.dailyGoal; notificationsEnabled = s.notificationsEnabled
+        reminderTime = s.reminderTime?.components
+        sessionLog = s.sessionLog; showStrokeHints = s.showStrokeHints
+        lessonProgress = s.lessonProgress; kanjiProgress = s.kanjiProgress
+        displayName = s.displayName; hasOnboarded = s.hasOnboarded
+    }
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ JapaneseBuddy sports a red sun app icon with kana and uses a warm accent tint th
 ## Goals & Reminders
 Set daily targets for new and review cards and track progress on the Home screen. Configure goals and optional local reminders in Settings; notifications stay on-device and are fully optional.
 
+## Backup & Restore
+In **Settings ▸ Backup & Restore** you can export your deck as `deck.json` or import a previously saved file. The file lives only on your device; sharing is manual and no data is sent elsewhere.
+
 ## Stroke Order
 Trace practice shows optional stroke hints with numbered overlays and an animated preview. Use the Play/Pause button before tracing; disable hints in Settings if preferred.
 


### PR DESCRIPTION
## Summary
- add BackupService to export and import deck.json with schema validation and atomic write
- add BackupSection in Settings using UIKit bridges for export/import
- document backup and restore steps in README

## Testing
- ⚠️ `make format` (swiftformat: No such file or directory)
- ⚠️ `make lint` (`swiftlint` not found)
- ⚠️ `make test` (`xcodebuild` not found)


------
https://chatgpt.com/codex/tasks/task_e_68ac628ecc84832ebbc7102b7b1b27dc