### PR TITLE
feat(settings): add deck backup and restore

### DIFF
--- a/.codex/checks/sanity.md
+++ b/.codex/checks/sanity.md
@@ -1,6 +1,6 @@
 # Sanity Snapshot
 
-- Updated: 2025-08-25T14:12:56Z
+- Updated: 2025-08-25T15:13:34Z
 
 ## Project
 - xcodeproj: present

--- a/.codex/state.json
+++ b/.codex/state.json
@@ -25,5 +25,5 @@
     "Onboarding hero uses aspect-fit; proportional tappable hotspot overlay"
   ],
   "context_notes": [],
-  "last_updated": "2025-08-25T14:12:57Z",
+  "last_updated": "2025-08-25T15:13:34Z",
 }

--- a/JapaneseBuddy/Features/Settings/BackupSection.swift
+++ b/JapaneseBuddy/Features/Settings/BackupSection.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+
+struct BackupSection: View {
+    @EnvironmentObject var store: DeckStore
+    @State private var showExporter = false
+    @State private var showImporter = false
+    @State private var alert: AlertInfo?
+
+    var body: some View {
+        Section("Backup & Restore") {
+            Button("Export deck.json") { showExporter = true }
+            Button("Import deck.json") { showImporter = true }
+        }
+        .sheet(isPresented: $showExporter) {
+            ActivityController(url: BackupService.exportURL)
+        }
+        .sheet(isPresented: $showImporter) {
+            DocumentPicker { url in
+                do {
+                    try BackupService.importDeck(from: url, into: store)
+                    alert = AlertInfo(title: "Import Complete")
+                } catch {
+                    alert = AlertInfo(title: "Import Failed", message: error.localizedDescription)
+                }
+            }
+        }
+        .alert(item: $alert) { info in
+            Alert(title: Text(info.title), message: Text(info.message ?? ""), dismissButton: .default(Text("OK")))
+        }
+    }
+}
+
+private struct AlertInfo: Identifiable {
+    let id = UUID()
+    var title: String
+    var message: String?
+}
+
+private struct ActivityController: UIViewControllerRepresentable {
+    let url: URL
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    }
+    func updateUIViewController(_ vc: UIActivityViewController, context: Context) {}
+}
+
+private struct DocumentPicker: UIViewControllerRepresentable {
+    var onPick: (URL) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(onPick: onPick) }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.json])
+        picker.allowsMultipleSelection = false
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ vc: UIDocumentPickerViewController, context: Context) {}
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onPick: (URL) -> Void
+        init(onPick: @escaping (URL) -> Void) { self.onPick = onPick }
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            onPick(url)
+        }
+    }
+}

--- a/JapaneseBuddy/Features/Settings/SettingsView.swift
+++ b/JapaneseBuddy/Features/Settings/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
             Section("Tracing") {
                 Toggle("Show Stroke Hints", isOn: $store.showStrokeHints)
             }
+            BackupSection()
             Section("Developer") {
                 Button("Reset Onboarding") { store.hasOnboarded = false }
                 .accessibilityLabel("Reset onboarding")

--- a/JapaneseBuddy/Services/BackupService.swift
+++ b/JapaneseBuddy/Services/BackupService.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum BackupService {
+    static var exportURL: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("deck.json")
+    }
+
+    enum BackupError: Error {
+        case invalidFormat
+    }
+
+    static func importDeck(from url: URL, into store: DeckStore) throws {
+        let data = try Data(contentsOf: url)
+        guard (try? JSONDecoder().decode(DeckStore.State.self, from: data)) != nil else {
+            throw BackupError.invalidFormat
+        }
+        try data.write(to: exportURL, options: .atomic)
+        store.reload()
+    }
+}

--- a/JapaneseBuddy/Services/DeckStore.swift
+++ b/JapaneseBuddy/Services/DeckStore.swift
@@ -79,6 +79,10 @@ final class DeckStore: ObservableObject {
         }
     }
 
+    func reload() {
+        load()
+    }
+
     private func save() {
         let reminder = reminderTime.map { State.ReminderTime($0) }
         let state = State(cards: cards, dailyGoal: dailyGoal, notificationsEnabled: notificationsEnabled, reminderTime: reminder, sessionLog: sessionLog, showStrokeHints: showStrokeHints, lessonProgress: lessonProgress, kanjiProgress: kanjiProgress, displayName: displayName, hasOnboarded: hasOnboarded)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ JapaneseBuddy sports a red sun app icon with kana and uses a warm accent tint th
 ## Goals & Reminders
 Set daily targets for new and review cards and track progress on the Home screen. Configure goals and optional local reminders in Settings; notifications stay on-device and are fully optional.
 
+## Backup & Restore
+Use **Settings ▸ Backup & Restore** to export or import your study deck. Export shares `deck.json` from the Documents folder via the system share sheet. Import validates the file then replaces the existing deck. All data stays local on your device.
+
 ## Stroke Order
 Trace practice shows optional stroke hints with numbered overlays and an animated preview. Use the Play/Pause button before tracing; disable hints in Settings if preferred.
 


### PR DESCRIPTION
## Summary
- add BackupService with schema-checked import and export URL
- present share sheet and document picker in Settings Backup & Restore section
- document backup and restore flow in README

## Testing
- `make format` *(fails: swiftformat missing)*
- `make lint`
- `make test` *(fails: xcodebuild missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac70abc660832ea9dbe5b7cbefc7ef