### PR TITLE
chore(gitignore): ignore .codex generated artifacts on dev_yordam

### DIFF
--- a/.codex/checks/sanity.md
+++ b/.codex/checks/sanity.md
@@ -1,6 +1,6 @@
 # Sanity Snapshot
 
-- Updated: 2025-08-26T09:05:55Z
+- Updated: 2025-08-26T09:40:20Z
 
 ## Project
 - xcodeproj: present

--- a/.codex/state.json
+++ b/.codex/state.json
@@ -25,5 +25,5 @@
     "Onboarding hero uses aspect-fit; proportional tappable hotspot overlay"
   ],
   "context_notes": [],
-  "last_updated": "2025-08-26T09:05:55Z",
+  "last_updated": "2025-08-26T09:40:20Z",
 }

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Pods/
 
 # macOS
 .DS_Store
+
+# Codex CLI session/memory artifacts
+.codex/


### PR DESCRIPTION
This change adds `.codex/` to `.gitignore` to prevent merge conflicts and noise from Codex CLI session/memory artifacts (e.g., `state.json`, `checks/sanity.md`). No source code changes.

After merging:
- Existing tracked `.codex` files in local branches can be untracked with:
  - `git rm -r --cached .codex && git commit -m "chore(gitignore): stop tracking .codex"`

Targeting `dev_yordam` to keep that branch clean of generated files.