### PR TITLE
fix: restore onboarding gating and merge main

### DIFF
--- a/.codex/checks/sanity.md
+++ b/.codex/checks/sanity.md
@@ -1,6 +1,6 @@
 # Sanity Snapshot
 
-- Updated: 2025-08-29T12:01:27Z
+- Updated: 2025-08-29T12:04:15Z
 
 ## Project
 - xcodeproj: present

--- a/.codex/state.json
+++ b/.codex/state.json
@@ -25,5 +25,5 @@
     "Onboarding hero uses aspect-fit; proportional tappable hotspot overlay"
   ],
   "context_notes": [],
-  "last_updated": "2025-08-29T12:01:27Z",
+  "last_updated": "2025-08-29T12:04:16Z",
 }

--- a/JapaneseBuddyProj/JapaneseBuddyProj/JapaneseBuddyProjApp.swift
+++ b/JapaneseBuddyProj/JapaneseBuddyProj/JapaneseBuddyProjApp.swift
@@ -23,11 +23,17 @@ struct JapaneseBuddyProjApp: App {
 
     var body: some Scene {
         WindowGroup {
-            AppSidebar()
-                .environmentObject(store)
-                .environmentObject(lessons)
-                .applyTheme(store.themeMode)
-                .tint(Color("AccentColor"))
+            Group {
+                if store.hasOnboarded {
+                    AppSidebar()
+                } else {
+                    OnboardingView()
+                }
+            }
+            .environmentObject(store)
+            .environmentObject(lessons)
+            .applyTheme(store.themeMode)
+            .tint(Color("AccentColor"))
         }
     }
 }


### PR DESCRIPTION
## Summary
- merge `main` and refresh codex state
- restore `OnboardingView` gating before showing `AppSidebar`

## Testing
- `make lint` *(swiftlint: not found)*
- `make test` *(xcodebuild: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b196d04b98832e82f4eb7d20d38e6a